### PR TITLE
Make Browsersync configurable

### DIFF
--- a/lib/local_server.coffee
+++ b/lib/local_server.coffee
@@ -39,6 +39,9 @@ class Server
 
     if @project.config.browser then _.merge(bs_options, @project.config.browser)
 
+    user_bs_config = @project.config.browsersync
+    if user_bs_config then _.merge(bs_options, user_bs_config)
+
     # add charge middleware after merge to prevent errors
     opts = @project.config.server or {}
     middlewares = []


### PR DESCRIPTION
Browsersync is now configurable by:

```coffee
browsersync:
  snippetOptions:
    rule:
      match: /<\/head>/i,
        fn: (snippet, match) ->
          return snippet + match
  ui:
    port: 8081
```